### PR TITLE
Add placeholder project for future business

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Web3Approved represents an initiative aimed to promote the decentralization of o
 | Coin Referece | https://coinreference.me | https://ipfs.apillon.io/ipns/k2k4r8kshvk61qn5sit2qof8rkz3ofztnpwhahu54eq8zgr22e6tez2h/ |
 | Otherproject | https://Otherproject.io      | https://ipfs.apillon.io/ipns/k2k4r8ly23zgyhsk2u91pprkls0i8zf1vkahjpt7k7pjeldkayd2tkx2/ |
 | Titus Blog | TBD      | https://ipfs.apillon.io/ipns/k2k4r8ktolbreuvqsio31ik1l922pqmd5j8nei9ndbw96ctfm3mu5xs7/ |
+| BeeSee | https://github.com/Chralt98/beesee | https://crustipfs.live/ipfs/QmSkDjtrPkmcMXQXDz6Zo4VjfzNUVtuRWen65yBeeN68zT/ |
 
 
 # Why should you host or backup your website on Web3? 


### PR DESCRIPTION
This is to ensure to secure a place for one of the hundred free website hostings (for 100 years) provided by Crust Network advertised [here](https://ipfs.apillon.io/ipns/k2k4r8osp5cj66k364xf308w40wrcj3mg7illmptgdl7mr2w41zaf8dd).

[100-website-free-hosting.pdf](https://github.com/Apillon/Web3Approved/files/14205001/100-website-free-hosting.pdf)

The name of this project and the https URL will change in a future PR to represent the real blockchain business intended to be released in the next 2-3 years, maybe earlier. I currently don't know when my project is mature enough to be released, but currently it is not. That's why I would want to secure the slot.